### PR TITLE
feat(client): Sync over WebChannel glue

### DIFF
--- a/app/scripts/lib/app-start.js
+++ b/app/scripts/lib/app-start.js
@@ -45,6 +45,7 @@ define([
   'models/reliers/fx-desktop',
   'models/auth_brokers/base',
   'models/auth_brokers/fx-desktop',
+  'models/auth_brokers/fx-desktop-v2',
   'models/auth_brokers/web-channel',
   'models/auth_brokers/redirect',
   'models/auth_brokers/iframe',
@@ -80,7 +81,8 @@ function (
   OAuthRelier,
   FxDesktopRelier,
   BaseAuthenticationBroker,
-  FxDesktopAuthenticationBroker,
+  FxDesktopV1AuthenticationBroker,
+  FxDesktopV2AuthenticationBroker,
   WebChannelAuthenticationBroker,
   RedirectAuthenticationBroker,
   IframeAuthenticationBroker,
@@ -304,12 +306,18 @@ function (
     },
 
     initializeAuthenticationBroker: function () {
+      //jshint maxcomplexity: 7
       if (! this._authenticationBroker) {
-        if (this._isFxDesktop()) {
-          this._authenticationBroker = new FxDesktopAuthenticationBroker({
+        if (this._isFxDesktopV2()) {
+          this._authenticationBroker = new FxDesktopV2AuthenticationBroker({
             window: this._window,
             relier: this._relier,
-            session: Session,
+            metrics: this._metrics
+          });
+        } else if (this._isFxDesktopV1()) {
+          this._authenticationBroker = new FxDesktopV1AuthenticationBroker({
+            window: this._window,
+            relier: this._relier,
             metrics: this._metrics
           });
         } else if (this._isWebChannel()) {
@@ -381,7 +389,7 @@ function (
     },
 
     initializeNotifications: function () {
-      var notificationWebChannel = new WebChannel(Constants.PROFILE_WEBCHANNEL_ID);
+      var notificationWebChannel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
       notificationWebChannel.init();
 
       this._notifications = new Notifications({
@@ -464,9 +472,28 @@ function (
       return Storage.factory('localStorage', this._window);
     },
 
+    _isSync: function () {
+      return this._searchParam('service') === Constants.FX_DESKTOP_SYNC;
+    },
+
+    _isFxDesktopV1: function () {
+      return this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT;
+    },
+
+    _isFxDesktopV2: function () {
+      // A user is signing into sync from within an iframe on a trusted
+      // web page. Automatically speak version 2 using WebChannels.
+      //
+      // A check for context=fx_desktop_v2 can be added when about:accounts
+      // is converted to use WebChannels.
+      return this._isSync() && this._isIframeContext();
+    },
+
     _isFxDesktop: function () {
-      return ((this._searchParam('service') === Constants.FX_DESKTOP_SYNC) ||
-              (this._searchParam('context') === Constants.FX_DESKTOP_CONTEXT));
+      // In addition to the two obvious fx desktop choices, sync is always
+      // considered fx-desktop. If service=sync is on the URL, it's considered
+      // fx-desktop.
+      return this._isFxDesktopV1() || this._isFxDesktopV2() || this._isSync();
     },
 
     _isWebChannel: function () {

--- a/app/scripts/lib/constants.js
+++ b/app/scripts/lib/constants.js
@@ -47,7 +47,7 @@ define([], function () {
 
     ONERROR_MESSAGE_LIMIT: 100,
 
-    PROFILE_WEBCHANNEL_ID: 'account_updates'
+    ACCOUNT_UPDATES_WEBCHANNEL_ID: 'account_updates'
   };
 });
 

--- a/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A variant of the FxDesktop broker that speaks "v2" of the protocol.
+ * Communication with the browser is done via WebChannels and each
+ * command is prefixed with `fxaccounts:`
+ *
+ * If Sync is iframed by web content, v2 of the protocol is assumed.
+ */
+
+'use strict';
+
+define([
+  './fx-desktop',
+  'lib/channels/web',
+  'lib/constants'
+
+], function (FxDesktopAuthenticationBroker, WebChannel, Constants) {
+
+  var FxDesktopV2AuthenticationBroker = FxDesktopAuthenticationBroker.extend({
+    _commands: {
+      CAN_LINK_ACCOUNT: 'fxaccounts:can_link_account',
+      CHANGE_PASSWORD: 'fxaccounts:change_password',
+      DELETE_ACCOUNT: 'fxaccounts:delete_account',
+      LOADED: 'fxaccounts:loaded',
+      LOGIN: 'fxaccounts:login'
+    },
+
+    createChannel: function () {
+      var channel = new WebChannel(Constants.ACCOUNT_UPDATES_WEBCHANNEL_ID);
+      channel.init({
+        window: this.window
+      });
+
+      return channel;
+    }
+  });
+
+  return FxDesktopV2AuthenticationBroker;
+});
+

--- a/app/scripts/models/auth_brokers/fx-desktop.js
+++ b/app/scripts/models/auth_brokers/fx-desktop.js
@@ -9,6 +9,7 @@
 'use strict';
 
 define([
+  'cocktail',
   'underscore',
   'models/auth_brokers/base',
   'models/auth_brokers/mixins/channel',
@@ -16,16 +17,32 @@ define([
   'lib/auth-errors',
   'lib/channels/fx-desktop',
   'lib/url'
-], function (_, BaseAuthenticationBroker, ChannelMixin, p, AuthErrors,
-        FxDesktopChannel, Url) {
+], function (Cocktail, _, BaseAuthenticationBroker, ChannelMixin, p, AuthErrors,
+  FxDesktopChannel, Url) {
 
   var FxDesktopAuthenticationBroker = BaseAuthenticationBroker.extend({
+    _commands: {
+      CAN_LINK_ACCOUNT: 'can_link_account',
+      CHANGE_PASSWORD: 'change_password',
+      DELETE_ACCOUNT: 'delete_account',
+      LOADED: 'loaded',
+      LOGIN: 'login'
+    },
+
+    /**
+     * Initialize the broker
+     *
+     * @param {Object} options
+     * @param {String} options.channel
+     *        Channel used to send commands to remote listeners.
+     * @param {Object} options.metrics
+     *        Metrics where events/errors can be logged.
+     */
     initialize: function (options) {
       options = options || {};
 
       // channel can be passed in for testing.
       this._channel = options.channel;
-      this._session = options.session;
       this._metrics = options.metrics;
 
       return BaseAuthenticationBroker.prototype.initialize.call(
@@ -33,7 +50,7 @@ define([
     },
 
     afterLoaded: function () {
-      return this.send('loaded');
+      return this.send(this._commands.LOADED);
     },
 
     beforeSignIn: function (email) {
@@ -42,7 +59,7 @@ define([
       // we should cancel the login to sync or not based on Desktop
       // specific checks and dialogs. It throws an error with
       // message='USER_CANCELED_LOGIN' and errno=1001 if that's the case.
-      return self.send('can_link_account', { email: email })
+      return self.request(self._commands.CAN_LINK_ACCOUNT, { email: email })
         .then(function (response) {
           if (response && response.data && ! response.data.ok) {
             throw AuthErrors.toError('USER_CANCELED_LOGIN');
@@ -91,23 +108,29 @@ define([
     },
 
     afterChangePassword: function (account) {
-      // no response is expected, so do not wait for one
-      this.send('change_password', this._getLoginData(account));
-      return p();
+      return this.send(
+          this._commands.CHANGE_PASSWORD, this._getLoginData(account));
     },
 
     afterDeleteAccount: function (account) {
       // no response is expected, so do not wait for one
-      this.send('delete_account', {
+      return this.send(this._commands.DELETE_ACCOUNT, {
         email: account.get('email'),
         uid: account.get('uid')
       });
-      return p();
     },
 
     // used by the ChannelMixin to get a channel.
     getChannel: function () {
-      var channel = this._channel || new FxDesktopChannel();
+      if (! this._channel) {
+        this._channel = this.createChannel();
+      }
+
+      return this._channel;
+    },
+
+    createChannel: function () {
+      var channel = new FxDesktopChannel();
 
       channel.init({
         window: this.window,
@@ -126,7 +149,7 @@ define([
     },
 
     _notifyRelierOfLogin: function (account) {
-      return this.send('login', this._getLoginData(account));
+      return this.send(this._commands.LOGIN, this._getLoginData(account));
     },
 
     _getLoginData: function (account) {
@@ -152,7 +175,10 @@ define([
     }
   });
 
-  _.extend(FxDesktopAuthenticationBroker.prototype, ChannelMixin);
+  Cocktail.mixin(
+    FxDesktopAuthenticationBroker,
+    ChannelMixin
+  );
 
   return FxDesktopAuthenticationBroker;
 });

--- a/app/tests/spec/lib/app-start.js
+++ b/app/tests/spec/lib/app-start.js
@@ -196,17 +196,18 @@ function (chai, sinon, AppStart, Session, Constants, p, Url, OAuthErrors,
       });
 
       describe('fx-desktop', function () {
-        it('returns an FxDesktop broker if `service=sync`', function () {
+        it('returns an FxDesktop broker if `context=fx_desktop_v1`', function () {
           windowMock.location.search = Url.objToSearchString({
-            service: Constants.FX_DESKTOP_SYNC
+            context: Constants.FX_DESKTOP_CONTEXT
           });
 
           return testExpectedBrokerCreated(FxDesktopBroker);
         });
 
-        it('returns an FxDesktop broker if `context=fx_desktop_v1`', function () {
+        it('returns an FxDesktop broker if `service=sync&context=iframe`', function () {
           windowMock.location.search = Url.objToSearchString({
-            context: Constants.FX_DESKTOP_CONTEXT
+            service: Constants.FX_DESKTOP_SYNC,
+            context: Constants.IFRAME_CONTEXT
           });
 
           return testExpectedBrokerCreated(FxDesktopBroker);

--- a/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+define([
+  'chai',
+  'sinon',
+  'lib/channels/null',
+  'lib/promise',
+  'models/auth_brokers/fx-desktop-v2',
+  '../../../mocks/window'
+], function (chai, sinon, NullChannel, p, FxDesktopV2AuthenticationBroker,
+  WindowMock) {
+  var assert = chai.assert;
+
+  describe('models/auth_brokers/fx-desktop-v2', function () {
+    var windowMock;
+    var channelMock;
+
+    var broker;
+
+    beforeEach(function () {
+      windowMock = new WindowMock();
+      channelMock = new NullChannel();
+      channelMock.send = function () {
+        return p();
+      };
+      channelMock.request = function () {
+        return p();
+      };
+
+      broker = new FxDesktopV2AuthenticationBroker({
+        window: windowMock,
+        channel: channelMock
+      });
+    });
+
+    describe('afterLoaded', function () {
+      it('sends an `fxaccounts:loaded` message', function () {
+        sinon.spy(channelMock, 'send');
+        return broker.afterLoaded()
+          .then(function () {
+            assert.isTrue(channelMock.send.calledWith('fxaccounts:loaded'));
+          });
+      });
+    });
+
+    describe('getChannel', function () {
+      it('creates a channel if not already available', function () {
+        delete broker._channel;
+        assert.ok(broker.getChannel());
+      });
+    });
+  });
+});

--- a/app/tests/spec/models/auth_brokers/fx-desktop.js
+++ b/app/tests/spec/models/auth_brokers/fx-desktop.js
@@ -14,15 +14,15 @@ define([
   'lib/auth-errors',
   'lib/channels/null',
   'lib/promise',
-  'lib/session',
   '../../../mocks/window'
 ], function (chai, sinon, _, FxDesktopAuthenticationBroker, User,
-        Constants, AuthErrors, NullChannel, p, Session, WindowMock) {
+        Constants, AuthErrors, NullChannel, p, WindowMock) {
   var assert = chai.assert;
 
   describe('models/auth_brokers/fx-desktop', function () {
     var windowMock;
     var channelMock;
+
     var broker;
     var user;
     var account;
@@ -30,6 +30,13 @@ define([
     beforeEach(function () {
       windowMock = new WindowMock();
       channelMock = new NullChannel();
+      channelMock.send = function () {
+        return p();
+      };
+      channelMock.request = function () {
+        return p();
+      };
+
       user = new User();
       account = user.initAccount({
         email: 'testuser@testuser.com'
@@ -37,59 +44,47 @@ define([
 
       broker = new FxDesktopAuthenticationBroker({
         window: windowMock,
-        channel: channelMock,
-        session: Session
+        channel: channelMock
       });
     });
 
     describe('afterLoaded', function () {
       it('sends a `loaded` message', function () {
-        sinon.stub(channelMock, 'send', function (message, data, done) {
-          if (message === 'loaded') {
-            done(null);
-          }
-        });
-
+        sinon.spy(channelMock, 'send');
         return broker.afterLoaded()
           .then(function () {
-            assert.isTrue(channelMock.send.called);
+            assert.isTrue(channelMock.send.calledWith('loaded'));
           });
       });
     });
 
     describe('beforeSignIn', function () {
       it('is happy if the user clicks `yes`', function () {
-        sinon.stub(channelMock, 'send', function (message, data, done) {
-          if (message === 'can_link_account') {
-            done(null, { data: { ok: true }});
-          }
+        sinon.stub(channelMock, 'request', function () {
+          return p({ data: { ok: true }});
         });
 
         return broker.beforeSignIn('testuser@testuser.com')
           .then(function () {
-            assert.isTrue(channelMock.send.called);
+            assert.isTrue(channelMock.request.calledWith('can_link_account'));
           });
       });
 
       it('throws a USER_CANCELED_LOGIN error if user rejects', function () {
-        sinon.stub(channelMock, 'send', function (message, data, done) {
-          if (message === 'can_link_account') {
-            done(null, { data: {} });
-          }
+        sinon.stub(channelMock, 'request', function () {
+          return p({ data: {}});
         });
 
         return broker.beforeSignIn('testuser@testuser.com')
           .then(assert.fail, function (err) {
             assert.isTrue(AuthErrors.is(err, 'USER_CANCELED_LOGIN'));
-            assert.isTrue(channelMock.send.called);
+            assert.isTrue(channelMock.request.calledWith('can_link_account'));
           });
       });
 
       it('swallows errors returned by the browser', function () {
-        sinon.stub(channelMock, 'send', function (message, data, done) {
-          if (message === 'can_link_account') {
-            done(new Error('uh oh'));
-          }
+        sinon.stub(channelMock, 'request', function () {
+          return p.reject(new Error('uh oh'));
         });
 
         sinon.spy(console, 'error');
@@ -104,51 +99,39 @@ define([
 
     describe('_notifyRelierOfLogin', function () {
       it('sends a `login` message to the channel', function () {
-        var data;
-        sinon.stub(channelMock, 'send', function (message, _data, done) {
-          if (message === 'login') {
-            data = _data;
-
-            done(null);
-          }
-        });
+        sinon.spy(channelMock, 'send');
 
         return broker._notifyRelierOfLogin(account)
           .then(function () {
+            assert.isTrue(channelMock.send.calledWith('login'));
+
+            var data = channelMock.send.args[0][1];
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verified);
             assert.isFalse(data.verifiedCanLinkAccount);
-            assert.isTrue(channelMock.send.called);
           });
       });
 
       it('sends a `login` message to the channel using current account data', function () {
-        var data;
-        sinon.stub(channelMock, 'send', function (message, _data, done) {
-          if (message === 'login') {
-            data = _data;
-
-            done(null);
-          }
-        });
+        sinon.spy(channelMock, 'send');
 
         return broker._notifyRelierOfLogin(account)
           .then(function () {
+            assert.isTrue(channelMock.send.calledWith('login'));
+
+            var data = channelMock.send.args[0][1];
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verified);
             assert.isFalse(data.verifiedCanLinkAccount);
-            assert.isTrue(channelMock.send.called);
           });
       });
 
       it('tells the window not to re-verify if the user can link accounts if the question has already been asked', function () {
-        var data;
-        sinon.stub(channelMock, 'send', function (message, _data, done) {
+        sinon.stub(channelMock, 'send', function (message) {
           if (message === 'can_link_account') {
-            return done(null, { data: { ok: true }});
+            return p({ data: { ok: true }});
           } else if (message === 'login') {
-            data = _data;
-            return done(null);
+            return p();
           }
         });
 
@@ -157,10 +140,11 @@ define([
             return broker._notifyRelierOfLogin(account);
           })
           .then(function () {
+            assert.equal(channelMock.send.args[0][0], 'login');
+            var data = channelMock.send.args[0][1];
             assert.equal(data.email, 'testuser@testuser.com');
             assert.isFalse(data.verified);
             assert.isTrue(data.verifiedCanLinkAccount);
-            assert.isTrue(channelMock.send.called);
           });
       });
 
@@ -168,13 +152,11 @@ define([
         // set account as verified
         account.set('verified', true);
 
-        var data;
-        sinon.stub(channelMock, 'send', function (message, _data, done) {
+        sinon.stub(channelMock, 'send', function (message) {
           if (message === 'can_link_account') {
-            return done(null, { data: { ok: true }});
+            return p({ data: { ok: true }});
           } else if (message === 'login') {
-            data = _data;
-            return done(null);
+            return p();
           }
         });
 
@@ -183,6 +165,7 @@ define([
             return broker._notifyRelierOfLogin(account);
           })
           .then(function () {
+            var data = channelMock.send.args[0][1];
             assert.isTrue(data.verified);
           });
       });
@@ -190,26 +173,43 @@ define([
 
     describe('afterSignIn', function () {
       it('notifies the channel of login', function () {
-        sinon.stub(broker, '_notifyRelierOfLogin', function () {
-          return p();
+        sinon.spy(broker, 'send');
+        account.set({
+          uid: 'uid',
+          sessionToken: 'session_token',
+          sessionTokenContext: 'sync',
+          unwrapBKey: 'unwrap_b_key',
+          keyFetchToken: 'key_fetch_token',
+          customizeSync: true,
+          verified: true,
+          notSent: 'not_sent'
         });
 
         return broker.afterSignIn(account)
-          .then(function () {
-            assert.isTrue(broker._notifyRelierOfLogin.calledWith(account));
+          .then(function (result) {
+
+            var args = broker.send.args[0];
+            assert.equal(args[0], 'login');
+            assert.equal(args[1].email, 'testuser@testuser.com');
+            assert.equal(args[1].uid, 'uid');
+            assert.equal(args[1].sessionToken, 'session_token');
+            assert.equal(args[1].sessionTokenContext, 'sync');
+            assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
+            assert.equal(args[1].customizeSync, true);
+            assert.equal(args[1].verified, true);
+
+            assert.isTrue(result.halt);
           });
       });
     });
 
     describe('beforeSignUpConfirmationPoll', function () {
       it('notifies the channel of login, halts the flow', function () {
-        sinon.stub(broker, '_notifyRelierOfLogin', function () {
-          return p();
-        });
+        sinon.spy(broker, 'send');
 
         return broker.beforeSignUpConfirmationPoll(account)
           .then(function (result) {
-            assert.isTrue(broker._notifyRelierOfLogin.calledWith(account));
+            assert.isTrue(broker.send.calledWith('login'));
             assert.isTrue(result.halt);
           });
       });
@@ -217,22 +217,19 @@ define([
 
     describe('afterResetPasswordConfirmationPoll', function () {
       it('notifies the channel of login', function () {
-        sinon.stub(broker, '_notifyRelierOfLogin', function () {
-          return p();
-        });
+        sinon.spy(broker, 'send');
 
-        return broker.afterResetPasswordConfirmationPoll()
-          .then(function () {
-            assert.isTrue(broker._notifyRelierOfLogin.called);
+        return broker.afterResetPasswordConfirmationPoll(account)
+          .then(function (result) {
+            assert.isTrue(broker.send.calledWith('login'));
+            assert.isTrue(result.halt);
           });
       });
     });
 
     describe('afterChangePassword', function () {
       it('notifies the channel of change_password with the new login info', function () {
-        sinon.spy(channelMock, 'send', function (message, data, done) {
-          done(null);
-        });
+        sinon.spy(broker, 'send');
 
         account.set({
           uid: 'uid',
@@ -247,7 +244,7 @@ define([
 
         return broker.afterChangePassword(account)
           .then(function () {
-            var args = channelMock.send.args[0];
+            var args = broker.send.args[0];
             assert.equal(args[0], 'change_password');
             assert.equal(args[1].email, 'testuser@testuser.com');
             assert.equal(args[1].uid, 'uid');
@@ -263,15 +260,13 @@ define([
 
     describe('afterDeleteAccount', function () {
       it('notifies the channel of delete_account', function () {
-        sinon.spy(channelMock, 'send', function (message, data, done) {
-          done(null);
-        });
+        sinon.spy(broker, 'send');
 
         account.set('uid', 'uid');
 
         return broker.afterDeleteAccount(account)
           .then(function () {
-            var args = channelMock.send.args[0];
+            var args = broker.send.args[0];
             assert.equal(args[0], 'delete_account');
             assert.equal(args[1].email, 'testuser@testuser.com');
             assert.equal(args[1].uid, 'uid');
@@ -279,5 +274,11 @@ define([
       });
     });
 
+    describe('getChannel', function () {
+      it('creates a channel if not already available', function () {
+        delete broker._channel;
+        assert.ok(broker.getChannel());
+      });
+    });
   });
 });

--- a/app/tests/test_start.js
+++ b/app/tests/test_start.js
@@ -101,6 +101,7 @@ function (Translator, Session) {
     '../tests/spec/models/reliers/fx-desktop',
     '../tests/spec/models/auth_brokers/base',
     '../tests/spec/models/auth_brokers/fx-desktop',
+    '../tests/spec/models/auth_brokers/fx-desktop-v2',
     '../tests/spec/models/auth_brokers/web-channel',
     '../tests/spec/models/auth_brokers/redirect',
     '../tests/spec/models/auth_brokers/oauth',


### PR DESCRIPTION
Make the FxDesktopAuthenticationBroker configurable so that it can use either a FxDesktop or Web channel.